### PR TITLE
Fix nvfbc patch failing on driver version 555 (closes #24)

### DIFF
--- a/src/lax_fbc.cc
+++ b/src/lax_fbc.cc
@@ -32,9 +32,10 @@ struct JumpPatchInfo
     std::string_view desc;
 };
 
-const std::array<JumpPatchInfo, 2> possible_patches =
+const std::array<JumpPatchInfo, 3> possible_patches =
 {{
-    {ZYDIS_MNEMONIC_JNZ, 0xA1, 6, "[555,)"},
+    {ZYDIS_MNEMONIC_JNZ, 0x102, 6, "[560, )"},
+    {ZYDIS_MNEMONIC_JNZ, 0xA1, 6, "[555, 560)"},
     {ZYDIS_MNEMONIC_JNB, 0x0A, 2, "[535, 555)"}
 }};
 

--- a/src/lax_fbc.cc
+++ b/src/lax_fbc.cc
@@ -9,6 +9,8 @@
     OR IMPLIED WARRANTY. IN NO EVENT WILL THE AUTHORS BE HELD
     LIABLE FOR ANY DAMAGES ARISING FROM THE USE OF THIS SOFTWARE.  */
 
+#include <array>
+#include <cstdint>
 #include <iostream>
 
 #include <LIEF/ELF.hpp>
@@ -21,6 +23,20 @@ using namespace LIEF::ELF;
 
 const char *app_name = "nvlax_fbc";
 const char *lib_name = "libnvidia-fbc.so.XXX";
+
+struct JumpPatchInfo
+{
+    ZydisMnemonic jump_op;
+    size_t jump_offset;
+    size_t jump_size;
+    std::string_view desc;
+};
+
+const std::array<JumpPatchInfo, 2> possible_patches =
+{{
+    {ZYDIS_MNEMONIC_JNZ, 0xA1, 6, "[555,)"},
+    {ZYDIS_MNEMONIC_JNB, 0x0A, 2, "[535, 555)"}
+}};
 
 int
 main (int argc,
@@ -76,34 +92,56 @@ main (int argc,
 
     PPK_ASSERT_ERROR(found);
 
+    bool success = false;
+    for (const auto& patch : possible_patches)
     {
-        auto v_backtrack_bytes = bin->get_content_from_virtual_address(offset - 0xA, 2);
+        auto v_backtrack_bytes = bin->get_content_from_virtual_address(offset - patch.jump_offset,
+                                                                           patch.jump_size);
 
         ZydisDecodedInstruction instr;
-        PPK_ASSERT_ERROR(ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder,
-                                                               v_backtrack_bytes.data(),
-                                                               v_backtrack_bytes.size(),
-                                                               &instr)));
+        if (!ZYAN_SUCCESS(ZydisDecoderDecodeBuffer(&decoder,
+                                                   v_backtrack_bytes.data(),
+                                                   v_backtrack_bytes.size(),
+                                                   &instr)))
+        {
+            continue;
+        }
 
 
 
-        PPK_ASSERT_ERROR(instr.mnemonic == ZYDIS_MNEMONIC_JNB);
+        if (instr.mnemonic != patch.jump_op)
+        {
+            continue;
+        }
 
         ZyanU64 addr;
-        PPK_ASSERT_ERROR(ZYAN_SUCCESS(ZydisCalcAbsoluteAddress(&instr,
-                                                               &instr.operands[0],
-                                                               offset - 0xA,
-                                                               &addr)));
+        if (!ZYAN_SUCCESS(ZydisCalcAbsoluteAddress(&instr,
+                                                   &instr.operands[0],
+                                                   offset - 0xA,
+                                                   &addr)))
+        {
+            continue;
+        }
 
         // hopefully more fail-safe
+        // leaving this as an assert because this should always pass if it gets here
         PPK_ASSERT_ERROR(addr == offset);
+
+        // NOP the jump
+        bin->patch_address(offset - patch.jump_offset,
+                           std::vector<std::uint8_t>(patch.jump_size, 0x90));
+        bin->write(output.data());
+        std::cout << "[+] patched successfully with patch \"" << patch.desc << "\"" << std::endl;
+        success = true;
+        break;
     }
 
-    // NOP the jump
-    bin->patch_address(offset - 0xA, { 0x90, 0x90 });
-    bin->write(output.data());
+    int retval = EXIT_SUCCESS;
+    if (!success)
+    {
+        std::cerr << "[+] all possible patches failed" << std::endl;
+        retval = EXIT_FAILURE;
+    }
 
-    std::cout << "[+] patched successfully\n";
-
-    return EXIT_SUCCESS;
+    return retval;
 }


### PR DESCRIPTION
The jump instruction that the NvFBC patch was looking for changed quite a bit in 555: it moved and is now an entirely different opcode. This patch is able to find it. I also tweaked the patching process a bit to be able to support multiple different versions of the library, since the new patch won't work on older versions. I tested* on 535, 545, 550, and 555, and all seem to work for me with these changes.

If older versions aren't a concern, then a lot of these changes could be removed and the offset / size information can just be updated instead.

[*] The trunk branch doesn't compile for me so I have to also apply some of the other patches in pull request for testing. Please let me know if I messed up in the cherry-pick for this PR. My original branch that fully works is [here](https://github.com/TheCodex6824/nvlax/tree/main).