### PR TITLE
Fix Reference to 'master' in 'https://github.com/lief-project/LIEF'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ CPMAddPackage("gh:zyantific/zydis#master")
 
 CPMAddPackage(
         NAME LIEF_SRC
-        GIT_TAG master
+        GIT_TAG main
         GITHUB_REPOSITORY lief-project/LIEF
         DOWNLOAD_ONLY YES
 )


### PR DESCRIPTION
Hey, when I pulled down nvlax today and tried to run cmake, the LIEF dependency lists the GIT_TAG as 'master', however there's no corresponding 'master' branch on https://github.com/lief-project/LIEF anymore.

This Pull Request changes the GIT_TAG field to 'main', which is the default branch, that I assume would previously have been 'master'.
